### PR TITLE
add support for modules

### DIFF
--- a/prototypes/entity/assembling-machines.lua
+++ b/prototypes/entity/assembling-machines.lua
@@ -55,6 +55,15 @@ local rocketAssembling = util.table.deepcopy(assemblingMachine1)
 rocketAssembling.name = "rocket-assembling-machine"
 rocketAssembling.localised_name = nil
 
+--support for modules
+rocketAssembling.module_specification = {module_slots = 4}
+rocketAssembling.allowed_effects = {
+  "consumption",
+  "speed",
+  "productivity",
+  "pollution"
+}
+
 rocketAssembling.icon      = data.raw["item"][rocketAssembling.name].icon
 rocketAssembling.icon_size = data.raw["item"][rocketAssembling.name].icon_size
 rocketAssembling.icons     = util.table.deepcopy(data.raw["item"][rocketAssembling.name].icons)

--- a/prototypes/item/assembling-machines.lua
+++ b/prototypes/item/assembling-machines.lua
@@ -4,6 +4,13 @@ data:extend{{
   icon = "__MoreScience__/graphics/icons/assembling-machine-4.png",
   icon_size = 64,
   --flags = {},
+  module_specification = {module_slots = 4},
+  allowed_effects = {
+        "consumption",
+        "speed",
+        "productivity",
+        "pollution"
+  },
   subgroup = "ms-science-" .. require("prototypes/settings").rocketParts.subgroup,
   order = "a[" .. require("prototypes/settings").rocketParts.subgroup .. "]-a-a[assembling-machine]",
   place_result = "rocket-assembling-machine",


### PR DESCRIPTION
As requested in the the Factorio mod portal (https://mods.factorio.com/mod/MoreScience/discussion/5e04d1be85df81000cc358d4)

Here is the code to implement supporting modules. It put the number of modules at 4, same as assembling machine 3 that it uses in the recipe.